### PR TITLE
Closures use ES6 fat arrow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You don't need to use `rereduce` for those reducers at all. But if you plan to m
 
 import {  createReducer  } from 'rereduce'
 
-const firstReducer =  createReducer(function (state = 0, action) {
+const firstReducer =  createReducer((state = 0, action) => {
   switch (action.type) {
     case 'increment': return state + 1
     case 'decrement': return state - 1
@@ -51,9 +51,7 @@ const firstReducer =  createReducer(function (state = 0, action) {
 })
 
 const secondReducer = createReducer({ firstReducer },
-  function (state = 0,action,{ firstReducer }) {
-    return firstReducer + 1
-  }
+  (state = 0,action,{ firstReducer }) => firstReducer + 1
 )
 
 const rootReducer = combineReducers({ firstReducer, secondReducer })

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export function createReducer() {
 
   const reducerDependenciesReducer = reducerMemoizer(combineReducers(reducerDependencies))
 
-  const liftedReducer = function (state = { value: undefined, __dependencies: undefined }, action) {
+  const liftedReducer = (state = { value: undefined, __dependencies: undefined }, action) => {
     const { value, __dependencies } = state
     const nextDependenciesState = reducerDependenciesReducer(__dependencies,action)
 

--- a/test/test_rereduce.js
+++ b/test/test_rereduce.js
@@ -80,7 +80,7 @@ suite('rereduce', () => {
 
   test('reducers can be time-travelled', () => {
 
-    const firstReducer =  createReducer(function (state = 0, action) {
+    const firstReducer =  createReducer((state = 0, action) => {
       switch (action.type) {
         case 'increment': return state + 1
         case 'decrement': return state - 1
@@ -89,9 +89,7 @@ suite('rereduce', () => {
     })
 
     const secondReducer = createReducer({ firstReducer },
-      function (state = 0,action,{ firstReducer }) {
-        return firstReducer + 1
-      }
+      (state = 0,action,{ firstReducer }) => firstReducer + 1
     )
 
     const rootReducer = combineReducers({ firstReducer, secondReducer })
@@ -127,7 +125,7 @@ suite('rereduce', () => {
     const secondReducerCalls = expect.createSpy(() => {  })
     const thirdReducerCalls = expect.createSpy(() => {  })
 
-    const firstReducer =  createReducer(function (state = { counter: 0 }, action) {
+    const firstReducer =  createReducer((state = { counter: 0 }, action) => {
       firstReducerCalls()
       switch (action.type) {
         case 'increment': return { counter: state.counter + 1 }
@@ -137,14 +135,14 @@ suite('rereduce', () => {
     })
 
     const secondReducer = createReducer({ firstReducer }, // declare dependency to firstReducer
-      function (state = 0,action,{ firstReducer }) {
+      (state = 0,action,{ firstReducer }) => {
         secondReducerCalls()
         return firstReducer.counter + 1
       }
     )
 
     const thirdReducer = createReducer({ firstReducer, secondReducer }, // declare dependency to firstReducer
-      function (state = 0,action,{ firstReducer,secondReducer }) {
+      (state = 0,action,{ firstReducer,secondReducer }) => {
         thirdReducerCalls()
         return { thirdResult: firstReducer.counter + secondReducer }
       }


### PR DESCRIPTION
Kept closures in new line for non-first reducers to maintain emphasis on the reducer that the function is dependent on. 
