### PR TITLE
Make reducers with dependencies always return object of shape `{value, _dependencies}`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,20 +61,9 @@ function parseArgs(args) {
 }
 
 function wrapState(state,dependencies) {
-  if ( typeof state === 'object' ) {
-    if ( typeof state.__dependencies !== 'undefined' ) {
-      throw new Error('__dependencies is a reserved state attribute name')
-    }
-    return {
-      ...state,
-      __dependencies: dependencies
-    }
-  }
-  else {
-    return {
-      value: state,
-      __dependencies: dependencies
-    }
+  return {
+    value: state,
+    __dependencies: dependencies
   }
 }
 

--- a/test/test_rereduce.js
+++ b/test/test_rereduce.js
@@ -179,7 +179,7 @@ suite('rereduce', () => {
     assert.equal(state.secondReducerState1, state.secondReducerState2)
     assert.equal(state.secondReducerState1, state.secondReducerState3)
 
-    assert.equal(state.thirdReducerState1.thirdResult, 5)
+    assert.equal(state.thirdReducerState1.value.thirdResult, 5)
     assert.equal(state.thirdReducerState1, state.thirdReducerState2)
     assert.equal(state.thirdReducerState1, state.thirdReducerState3)
   })


### PR DESCRIPTION
Original issue: https://github.com/slorber/rereduce/issues/4
